### PR TITLE
MDS-383 | Added cache key implementation

### DIFF
--- a/app/uk/gov/hmrc/individualsdetailsapi/connectors/IfConnector.scala
+++ b/app/uk/gov/hmrc/individualsdetailsapi/connectors/IfConnector.scala
@@ -36,9 +36,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class IfConnector @Inject()(
-    servicesConfig: ServicesConfig,
-    http: HttpClient)(implicit ec: ExecutionContext) {
+class IfConnector @Inject()(servicesConfig: ServicesConfig, http: HttpClient)(
+    implicit ec: ExecutionContext) {
 
   private val baseUrl = servicesConfig.baseUrl("integration-framework")
   private val integrationFrameworkBearerToken =

--- a/app/uk/gov/hmrc/individualsdetailsapi/services/ScopesService.scala
+++ b/app/uk/gov/hmrc/individualsdetailsapi/services/ScopesService.scala
@@ -57,6 +57,9 @@ class ScopesService @Inject()(configuration: Configuration) {
     getFieldNames(authorizedDataItemsOnEndpoint)
   }
 
+  def getValidFieldsForCacheKey(scopes: List[String]): String =
+    scopes.flatMap(getScopeItemsKeys).distinct.reduce(_ + _)
+
   def getAccessibleEndpoints(scopes: List[String]): Iterable[String] = {
     val scopeKeys = scopes.flatMap(s => getScopeItemsKeys(s))
     apiConfig.endpoints

--- a/test/it/uk/gov/hmrc/individualsdetailsapi/connectors/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsdetailsapi/connectors/IfConnectorSpec.scala
@@ -1,20 +1,50 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package it.uk.gov.hmrc.individualsdetailsapi.connectors
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, configureFor, equalTo, get, stubFor, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  aResponse,
+  configureFor,
+  equalTo,
+  get,
+  stubFor,
+  urlPathMatching
+}
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import org.scalatest.BeforeAndAfterEach
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import testUtils.TestHelpers
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, Upstream5xxResponse}
+import uk.gov.hmrc.http.{
+  BadRequestException,
+  HeaderCarrier,
+  Upstream5xxResponse
+}
 import uk.gov.hmrc.individualsdetailsapi.connectors.IfConnector
 import unit.uk.gov.hmrc.individualsdetailsapi.utils.SpecBase
 
 import scala.concurrent.ExecutionContext
 
-class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with TestHelpers {
+class IfConnectorSpec
+    extends SpecBase
+    with BeforeAndAfterEach
+    with TestHelpers {
   val stubPort = sys.env.getOrElse("WIREMOCK", "11122").toInt
   val stubHost = "localhost"
   val wireMockServer = new WireMockServer(wireMockConfig().port(stubPort))
@@ -34,7 +64,8 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with TestHelpers 
     )
     .build()
 
-  implicit val ec: ExecutionContext = fakeApplication.injector.instanceOf[ExecutionContext]
+  implicit val ec: ExecutionContext =
+    fakeApplication.injector.instanceOf[ExecutionContext]
 
   trait Setup {
     implicit val hc = HeaderCarrier()
@@ -79,7 +110,9 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with TestHelpers 
     "for standard response" in new Setup {
       stubFor(
         get(urlPathMatching(s"/individuals/details/nino/$nino"))
-          .withHeader("Authorization", equalTo(s"Bearer $integrationFrameworkAuthorizationToken"))
+          .withHeader(
+            "Authorization",
+            equalTo(s"Bearer $integrationFrameworkAuthorizationToken"))
           .withHeader("Environment", equalTo(integrationFrameworkEnvironment))
           .willReturn(aResponse()
             .withStatus(200)

--- a/test/it/uk/gov/hmrc/individualsdetailsapi/services/CacheServiceSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsdetailsapi/services/CacheServiceSpec.scala
@@ -23,7 +23,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Json, OFormat}
 import play.api.test.Helpers.running
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.individualsdetailsapi.services.cache.CacheService
+import uk.gov.hmrc.individualsdetailsapi.services.cache.{
+  CacheIdBase,
+  CacheService
+}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -44,12 +47,14 @@ class CacheServiceSpec
 
       val app = new GuiceApplicationBuilder().build()
 
+      val cacheId = TestCacheId("foo")
+
       running(app) {
 
         val svc = app.injector.instanceOf[CacheService]
 
         svc
-          .get("foo", Future.successful(TestClass("bar")))
+          .get(cacheId, Future.successful(TestClass("bar")))
           .futureValue mustEqual TestClass("bar")
 
       }
@@ -59,24 +64,29 @@ class CacheServiceSpec
 
       val app = new GuiceApplicationBuilder().build()
 
+      val cacheId1 = TestCacheId("foo")
+      val cacheId2 = TestCacheId("bar")
+
       running(app) {
 
         val svc = app.injector.instanceOf[CacheService]
 
         svc
-          .get("foo", Future.successful(TestClass("bar")))
+          .get(cacheId1, Future.successful(TestClass("bar")))
           .futureValue mustEqual TestClass("bar")
         svc
-          .get("foo", Future.successful(TestClass("miss")))
+          .get(cacheId1, Future.successful(TestClass("miss")))
           .futureValue mustEqual TestClass("bar")
         svc
-          .get("bar", Future.successful(TestClass("miss")))
+          .get(cacheId2, Future.successful(TestClass("miss")))
           .futureValue mustEqual TestClass("miss")
 
       }
     }
   }
 }
+
+case class TestCacheId(id: String) extends CacheIdBase
 
 case class TestClass(param: String)
 

--- a/test/testUtils/TestHelpers.scala
+++ b/test/testUtils/TestHelpers.scala
@@ -16,7 +16,13 @@
 
 package testUtils
 
-import uk.gov.hmrc.individualsdetailsapi.domains.integrationframework.{IfAddress, IfContactDetail, IfDetails, IfDetailsResponse, IfResidence}
+import uk.gov.hmrc.individualsdetailsapi.domains.integrationframework.{
+  IfAddress,
+  IfContactDetail,
+  IfDetails,
+  IfDetailsResponse,
+  IfResidence
+}
 
 import scala.util.Random
 
@@ -53,8 +59,10 @@ trait TestHelpers {
     val ninoDetails = IfDetails(Some("XH123456A"), None)
     val contactDetail1 = IfContactDetail(9, "MOBILE TELEPHONE", "07123 987654")
     val contactDetail2 = IfContactDetail(9, "MOBILE TELEPHONE", "07123 987655")
-    val residence1 = IfResidence(residenceType = Some("BASE"), address = generateAddress(2))
-    val residence2 = IfResidence(residenceType = Some("NOMINATED"), address = generateAddress(1))
+    val residence1 =
+      IfResidence(residenceType = Some("BASE"), address = generateAddress(2))
+    val residence2 = IfResidence(residenceType = Some("NOMINATED"),
+                                 address = generateAddress(1))
 
     IfDetailsResponse(
       ninoDetails,

--- a/test/unit/uk/gov/hmrc/individualsdetailsapi/services/ScopesServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsdetailsapi/services/ScopesServiceSpec.scala
@@ -70,6 +70,25 @@ class ScopesServiceSpec
                            "employer/employerDistrictNumber")
     }
 
+    "get valid data items keys for single scope" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(List(mockScope1))
+      result shouldBe "ABF"
+    }
+
+    "get valid data items keys for multiple scopes" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(List(mockScope1, mockScope2))
+      result shouldBe "ABFCDEG"
+    }
+
+    "get valid data items keys for multiple scopes including no match" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(
+          List(mockScope1, mockScope2, "not-exists"))
+      result shouldBe "ABFCDEG"
+    }
+
     "identity accesssible endpoints" in {
       val result = scopesService.getAccessibleEndpoints(List(mockScope3)).toList
       result.contains(mockEndpoint1) shouldBe true


### PR DESCRIPTION
**Design:**

Our handler pattern maps data items to scopes.
I.e. [A, B, C]
Where;
A = address line 1
B = address line 2
C = address line 3 etc
So the cache key can use the data item keys “[A, B, C]”

This can then be concatenated for multiple scopes.
Example;
read:scope-1 = [A, B, C]
read:scope-2 = [D, E, F]
The cache key (if two scopes alone) would be;
id + [A, B, C, D, E, F] Or formatted to id-ABCDEF